### PR TITLE
feat: enable prefix for friendly profile names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Builds multi-profile configuration file after reading [Identity Centre's Access 
 
 Copy the distributed awssso.cfg-dist example, to awssso.cfg, and modify as required to your environment. The \[Profile\] block is required, the \*-mappings sections provide quality of life capabilities, as detailed below.
 
+Different config file can be provided with the --configfile parameter
+
 ### Profile
 
 *Region* and *sso_region* should be self explanatory, and dependent on your use-case. 

--- a/awssso.cfg-dist
+++ b/awssso.cfg-dist
@@ -10,6 +10,9 @@ output = json
 # configparser is case insensitive 
 # Everything will be lower case regardless
 [account-mappings]
+# If prefix is required for profile name, uncomment next line
+# ProfilePrefix = prefix-
+
 # remove any spaces in account name
 canonicalaccount = friendl_name
 account2 = friendly2

--- a/awssso.py
+++ b/awssso.py
@@ -8,6 +8,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from pprint import pprint
 
 
 # No idea why SSO can't leverage standard --profile from config
@@ -30,6 +31,9 @@ def cleanse_account_name(account_name, account_mappings):
     if account_name in account_mappings:
         # If the account name exists in the mappings, replace it with the friendly name
         account_name = account_mappings[account_name]
+
+    if "profileprefix" in account_mappings:
+        account_name = account_mappings["profileprefix"] + account_name
     return account_name
 
 


### PR DESCRIPTION
Simple functionality to prefix profile names with a string.

Enables easy differentiation if you're working with multiple AWS Organisations

Closes #2 