### PR TITLE
feat: support multiple SSO organisations in one config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ awssso.sh
 aws-sso.sh
 awssso.cfg
 output.cfg
+awssso.backup
+__pycache__/
+config.out

--- a/README.md
+++ b/README.md
@@ -7,15 +7,23 @@ Builds multi-profile configuration file after reading [Identity Centre's Access 
 
 ## Config File
 
-Copy the distributed awssso.cfg-dist example, to awssso.cfg, and modify as required to your environment. The \[Profile\] block is required, the \*-mappings sections provide quality of life capabilities, as detailed below.
+Copy the distributed awssso.cfg-dist example, to awssso.cfg, and modify as required to your environment. Declare one `[sso-session NAME]` block per AWS Organisation; the `\*-mappings` sections provide quality of life capabilities, as detailed below.
 
 Different config file can be provided with the --configfile parameter
 
-### Profile
+### sso-session
 
-*Region* and *sso_region* should be self explanatory, and dependent on your use-case. 
-*Output* is personal preference, 
-*sso_start_url* is the base of your existing IAM Identity Centre Setup, see [AWS Docs](https://docs.aws.amazon.com/singlesignon/latest/userguide/howtochangeURL.html) for more info if required.
+Each `[sso-session NAME]` block describes one Organisation's IAM Identity Centre instance:
+
+- *sso_start_url* is the base of your existing IAM Identity Centre Setup, see [AWS Docs](https://docs.aws.amazon.com/singlesignon/latest/userguide/howtochangeURL.html) for more info if required.
+- *sso_region* is the region your Identity Centre is hosted in — the tool talks to the SSO API here.
+- *region* and *output* control the generated profiles and can be set per session or shared via a `[defaults]` block. *Output* is personal preference.
+
+`NAME` becomes the `sso_session` name in the generated `~/.aws/config`, and is what you pass to `aws sso login --sso-session NAME`. Because profiles reference a shared `[sso-session]`, the AWS CLI (v2.9.0+) automatically refreshes the hourly access token, so you can switch between any profile — across any configured org — without re-authenticating until the underlying portal session expires.
+
+Multiple sessions can be logged in at once: each writes its own token file under `~/.aws/sso/cache/`, and the tool locates the correct one by matching the `startUrl` inside each cached token (not the newest file).
+
+**Legacy format:** a single `[profile]` block (the original single-org format) is still accepted and treated as one session.
 
 ### \*-mappings
 The two \*-appings sections provide quality of life capabilities to translate both AWS Account names and Role names to user prefered alternatives. For example shortening the defualt **AdministratorAccess** to shorthand of just **admin**
@@ -25,21 +33,28 @@ As the generated profile names could be used many times from CLI *aws --profile 
 Typically run the script once to see the default output, before updating the awssso.cfg file to tweak as desired.
 
 # Running Tool
-Running the utility is relatively straightforward, typical 'make executable, and run':
+First log in to each configured org (once per session), then run the utility:
 ```
+aws sso login --sso-session orga
+aws sso login --sso-session orgb
 chmod +x awssso.py
 ./awssso.py
 ```
+Any session without a valid cached token is skipped with a warning naming the `aws sso login` command to run.
 
 ## Example output
 ```
-[profile work-ro]
-sso_start_url = https://work.awsapps.com/start#/
+[sso-session work]
+sso_start_url = https://work.awsapps.com/start
 sso_region = eu-west-1
-region = eu-west-1
-output = json
+sso_registration_scopes = sso:account:access
+
+[profile work-ro]
+sso_session = work
 sso_account_id = 00000000227
 sso_role_name = ViewOnlyAccess
+region = eu-west-1
+output = json
 ```
 
 ## ~/.aws/config

--- a/awssso.cfg-dist
+++ b/awssso.cfg-dist
@@ -1,23 +1,46 @@
-# Update core profile preferences
-[profile]
-# Get you SSO Start URL from AWS Portal
-sso_start_url = https://<YOUR-DOMANI>.awsapps.com/start#/
+# awssso config — multi-organisation example
+#
+# Declare one [sso-session NAME] section per AWS Organisation (SSO instance).
+# NAME is used both as the sso-session name in the generated ~/.aws/config and,
+# via its sso_start_url, to locate the right cached token. Log in per org with:
+#   aws sso login --sso-session NAME
+
+# Shared defaults, inherited by any session that omits region/output.
+[defaults]
 region = eu-west-1
-sso_region = eu-west-1
 output = json
 
-# WARNING
-# configparser is case insensitive 
-# Everything will be lower case regardless
-[account-mappings]
-# If prefix is required for profile name, uncomment next line
-# ProfilePrefix = prefix-
+[sso-session orga]
+# Get your SSO Start URL from the AWS access portal.
+sso_start_url = https://<YOUR-DOMAIN>.awsapps.com/start
+sso_region = eu-west-1
 
+[sso-session orgb]
+sso_start_url = https://<OTHER-DOMAIN>.awsapps.com/start
+sso_region = us-east-1
+region = us-east-1          # optional per-session override of [defaults]
+# profileprefix is optional and per-session. Set a distinct value on each org
+# to disambiguate accounts that share a name across orgs, e.g:
+# profileprefix = orgb-
+
+# WARNING
+# configparser is case insensitive
+# Everything will be lower case regardless — write mapping keys lower-cased.
+[account-mappings]
 # remove any spaces in account name
-canonicalaccount = friendl_name
+canonicalaccount = friendly_name
 account2 = friendly2
 
 [role-mappings]
 longprofile = friendlyprofile
-ViewOnlyAccess = ro
-AdministratorAccess = admin
+viewonlyaccess = ro
+administratoraccess = admin
+
+# ----------------------------------------------------------------------------
+# Legacy single-organisation format (still supported):
+#
+# [profile]
+# sso_start_url = https://<YOUR-DOMAIN>.awsapps.com/start
+# region = eu-west-1
+# sso_region = eu-west-1
+# output = json

--- a/awssso.py
+++ b/awssso.py
@@ -7,23 +7,63 @@ import glob
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
-from pprint import pprint
 
 
-# No idea why SSO can't leverage standard --profile from config
-# Scrape access token from local SSO cache
-def get_sso_token():
+# No idea why SSO can't leverage standard --profile from config.
+# Locate the cached access token for a specific SSO start URL.
+#
+# The AWS CLI stores one JSON file per SSO session under ~/.aws/sso/cache/.
+# The filename is a SHA1 of the sso-session name (or start URL) but AWS does
+# not guarantee that scheme, and `aws sso login` and botocore have been known
+# to disagree on it, so we match on the startUrl field *inside* each file
+# instead of recomputing the hash. This also lets multiple orgs coexist.
+def get_sso_token(start_url):
     sso_cache_dir = Path.home() / ".aws" / "sso" / "cache"
-    files_path = os.path.join(sso_cache_dir, "*")
-    files = sorted(glob.iglob(files_path), key=os.path.getctime, reverse=True)
-    latest_cache_file = files[0]
+    files_path = os.path.join(sso_cache_dir, "*.json")
 
-    cache = json.loads(Path(latest_cache_file).read_text())
-    return cache.get("accessToken", None)
+    wanted = _normalise_url(start_url)
+    for cache_file in glob.iglob(files_path):
+        try:
+            cache = json.loads(Path(cache_file).read_text())
+        except (ValueError, OSError):
+            continue
+
+        if _normalise_url(cache.get("startUrl", "")) != wanted:
+            continue
+
+        token = cache.get("accessToken")
+        if not token:
+            continue
+
+        if _token_expired(cache.get("expiresAt")):
+            # Keep looking — an older, valid token may exist for the same URL.
+            continue
+
+        return token
+
+    return None
 
 
-def cleanse_account_name(account_name, account_mappings):
+def _normalise_url(url):
+    # Trailing slashes/hashes vary between how users type the URL and how the
+    # CLI records it; normalise so matching is reliable.
+    return url.rstrip("/#").lower()
+
+
+def _token_expired(expires_at):
+    if not expires_at:
+        return False
+    try:
+        # expiresAt is ISO-8601, typically "2026-07-20T08:30:00Z".
+        expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return False
+    return expiry <= datetime.now(timezone.utc)
+
+
+def cleanse_account_name(account_name, account_mappings, prefix=""):
     # Example: Replace spaces with underscores and strip leading/trailing whitespace
     account_name = account_name.replace(" ", "").strip()
     account_name = account_name.lower()
@@ -32,8 +72,10 @@ def cleanse_account_name(account_name, account_mappings):
         # If the account name exists in the mappings, replace it with the friendly name
         account_name = account_mappings[account_name]
 
-    if "profileprefix" in account_mappings:
-        account_name = account_mappings["profileprefix"] + account_name
+    # Prefix is per-session (see load_sessions) so overlapping account names across
+    # orgs can be disambiguated. Empty by default.
+    if prefix:
+        account_name = prefix + account_name
     return account_name
 
 
@@ -48,67 +90,167 @@ def cleanse_role_name(role_name, role_mappings):
     return role_name
 
 
+# Collect every SSO session declared in the config file.
+#
+# Preferred format: one [sso-session NAME] section per org. Shared region/output
+# can live in a [defaults] section. For backwards compatibility, a lone [profile]
+# section (the original single-org format) is promoted to a single session.
+def load_sessions(config):
+    defaults = config._sections.get("defaults", {})
+    sessions = []
+
+    for section in config.sections():
+        if not section.startswith("sso-session "):
+            continue
+        name = section[len("sso-session "):].strip()
+        values = config._sections.get(section, {})
+        start_url = values.get("sso_start_url")
+        sso_region = values.get("sso_region")
+        if not start_url or not sso_region:
+            print(
+                f"Warning: [sso-session {name}] missing sso_start_url or "
+                f"sso_region — skipping",
+                file=sys.stderr,
+            )
+            continue
+        sessions.append(
+            {
+                "name": name,
+                "sso_start_url": start_url,
+                "sso_region": sso_region,
+                "region": values.get("region", defaults.get("region", sso_region)),
+                "output": values.get("output", defaults.get("output", "json")),
+                # Per-session, no prefix unless explicitly set. Lets overlapping
+                # account names across orgs be disambiguated when needed.
+                "profileprefix": values.get("profileprefix", ""),
+            }
+        )
+
+    if sessions:
+        return sessions
+
+    # Backwards-compatible single-org [profile] format.
+    if config.has_section("profile"):
+        profile = config._sections.get("profile", {})
+        account_mappings = config._sections.get("account-mappings", {})
+        prefix = account_mappings.get("profileprefix", "")
+        name = prefix.rstrip("-_ ") or "default"
+        start_url = profile.get("sso_start_url")
+        sso_region = profile.get("sso_region")
+        if start_url and sso_region:
+            sessions.append(
+                {
+                    "name": name,
+                    "sso_start_url": start_url,
+                    "sso_region": sso_region,
+                    "region": profile.get("region", sso_region),
+                    "output": profile.get("output", "json"),
+                    # Legacy format: prefix stays global (from [account-mappings]).
+                    "profileprefix": prefix,
+                }
+            )
+
+    return sessions
+
+
+# Print the [sso-session] block once per org. Referencing profiles via
+# sso_session enables the AWS CLI's automatic token refresh.
+def build_session_block(session):
+    block = f"[sso-session {session['name']}]\n"
+    block += f"sso_start_url = {session['sso_start_url']}\n"
+    block += f"sso_region = {session['sso_region']}\n"
+    block += "sso_registration_scopes = sso:account:access\n"
+    print(block)
+
+
 # combine components to [profile] block for .aws/config file
-def build_profile_block(conf, account, role):
-    # TODO: Strip whitespace from within account and role name
-    # Option: extra function combing strip and name translation?
-
-    conf_profile = conf["profile"]
-
+def build_profile_block(conf, session, account, role):
     account_mappings = conf._sections.get("account-mappings", {})
     role_mappings = conf._sections.get("role-mappings", {})
-    friendly_name = cleanse_account_name(account.get("accountName"), account_mappings)
+    friendly_name = cleanse_account_name(
+        account.get("accountName"), account_mappings, session.get("profileprefix", "")
+    )
     friendly_role = cleanse_role_name(role.get("roleName"), role_mappings)
 
     block = f"[profile {friendly_name}-{friendly_role}]\n"
-    block += f"sso_start_url = {conf_profile['sso_start_url']}\n"
-    block += f"sso_region = {conf_profile['sso_region']}\n"
-    block += f"region = {conf_profile['region']}\n"
-    block += f"output = {conf_profile['output']}\n"
+    block += f"sso_session = {session['name']}\n"
     block += f"sso_account_id = {account.get('accountId')}\n"
     block += f"sso_role_name = {role.get('roleName')}\n"
+    block += f"region = {session['region']}\n"
+    block += f"output = {session['output']}\n"
     print(block)
-    pass
+
+
+def emit_profiles_for_session(config, session):
+    token = get_sso_token(session["sso_start_url"])
+    if token is None:
+        print(
+            f"Warning: no valid cached token for session '{session['name']}'. "
+            f"Run: aws sso login --sso-session {session['name']}",
+            file=sys.stderr,
+        )
+        return
+
+    client = boto3.client("sso", region_name=session["sso_region"])
+
+    accounts = []
+    try:
+        account_paginator = client.get_paginator("list_accounts")
+        for page in account_paginator.paginate(accessToken=token):
+            accounts.extend(page.get("accountList", []))
+    except Exception as e:
+        print(
+            f"Error retrieving accounts for session '{session['name']}': {e}",
+            file=sys.stderr,
+        )
+        return
+
+    build_session_block(session)
+
+    for account in accounts:
+        account_id = account.get("accountId")
+        roles = []
+        try:
+            role_paginator = client.get_paginator("list_account_roles")
+            for page in role_paginator.paginate(
+                accountId=account_id, accessToken=token
+            ):
+                roles.extend(page.get("roleList", []))
+
+            for role in roles:
+                build_profile_block(config, session, account, role)
+        except Exception as e:
+            print(
+                f"Error retrieving roles for account {account_id}: {e}",
+                file=sys.stderr,
+            )
 
 
 @click.command()
 @click.option("--configfile", default="awssso.cfg", help="Path to configuration file")
 def main(configfile):
 
+    # This tool authenticates to SSO purely via the cached accessToken, so it
+    # needs no AWS profile. Strip any ambient profile env vars, otherwise boto3's
+    # default-session setup tries to resolve them and crashes with ProfileNotFound
+    # when the caller's active profile isn't in the config file being read.
+    os.environ.pop("AWS_PROFILE", None)
+    os.environ.pop("AWS_DEFAULT_PROFILE", None)
+
     config = configparser.ConfigParser()
     config.read(configfile)
 
-    # extract token from sso cache
-    token = get_sso_token()
-    client = boto3.client("sso", region_name="eu-west-1")
-
-    accounts = []
-    # Retrieve account assignments
-    try:
-        account_paginator = client.get_paginator("list_accounts")
-        response_iterator = account_paginator.paginate(accessToken=token)
-        for page in response_iterator:
-            accounts.extend(page.get("accountList"))
-    except Exception as e:
-        print(f"Error retrieving assigned Accounts: {e}")
+    sessions = load_sessions(config)
+    if not sessions:
+        print(
+            "Error: no SSO sessions found. Define one or more [sso-session NAME] "
+            "sections (or a legacy [profile] section). See the README.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
-    for account in accounts:
-        roles = []
-        account_id = account.get("accountId")
-        try:
-            # List roles for the account
-            role_paginator = client.get_paginator("list_account_roles")
-            response_iterator = role_paginator.paginate(
-                accountId=account_id, accessToken=token
-            )
-            for page in response_iterator:
-                roles.extend(page.get("roleList", []))
-
-            for role in roles:
-                build_profile_block(config, account, role)
-        except Exception as e:
-            print(f"Error retrieving roles for Account {account_id}: {e}")
+    for session in sessions:
+        emit_profiles_for_session(config, session)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds multi-organisation support: read one or more `[sso-session NAME]` sections and generate a combined `~/.aws/config` covering every org, using refreshable `sso_session`-based profiles so users can switch between any profile — across orgs — without re-authenticating.

## Changes
- **Multi-org config**: one `[sso-session NAME]` per org, optional shared `[defaults]`. Legacy single `[profile]` format still accepted.
- **Correct token lookup**: match on the `startUrl` inside `~/.aws/sso/cache/*.json` instead of picking the newest file, so multiple orgs can be logged in concurrently.
- **Refreshable output**: emit `[sso-session]` blocks + profiles referencing them via `sso_session =` (AWS-recommended; the legacy inline form does not auto-refresh).
- **Per-session region**: use each session's `sso_region` for API calls (was hardcoded to `eu-west-1`).
- **Per-session `profileprefix`**: disambiguate overlapping account names across orgs (defaults to none).
- **Robustness**: strip ambient `AWS_PROFILE`/`AWS_DEFAULT_PROFILE` so the tool is unaffected by the caller's active profile.

## Testing
Verified end-to-end against two live orgs: concurrent auth, combined config generation, and `sts get-caller-identity` resolving profiles from both orgs without re-auth.